### PR TITLE
Add locale data for date, datetime and pickers

### DIFF
--- a/app/models/effective/form_inputs/date_field.rb
+++ b/app/models/effective/form_inputs/date_field.rb
@@ -10,7 +10,7 @@ module Effective
       end
 
       def input_js_options
-        { format: format, showTodayButton: false, showClear: false, useCurrent: 'hour', disabledDates: disabled_dates.presence, minDate: min_date.presence, maxDate: max_date.presence }.compact
+        { format: format, showTodayButton: false, showClear: false, useCurrent: 'hour', disabledDates: disabled_dates.presence, minDate: min_date.presence, maxDate: max_date.presence, locale: I18n.locale }.compact
       end
 
       def input_group_options

--- a/app/models/effective/form_inputs/datetime_field.rb
+++ b/app/models/effective/form_inputs/datetime_field.rb
@@ -10,7 +10,7 @@ module Effective
       end
 
       def input_js_options
-        { format: format, sideBySide: true, showTodayButton: false, showClear: false, useCurrent: 'hour', disabledDates: disabled_dates.presence, minDate: min_date.presence, maxDate: max_date.presence }.compact
+        { format: format, sideBySide: true, showTodayButton: false, showClear: false, useCurrent: 'hour', disabledDates: disabled_dates.presence, minDate: min_date.presence, maxDate: max_date.presence, locale: I18n.locale }.compact
       end
 
       def input_group_options

--- a/app/models/effective/form_inputs/time_field.rb
+++ b/app/models/effective/form_inputs/time_field.rb
@@ -10,7 +10,7 @@ module Effective
       end
 
       def input_js_options
-        { format: format, showTodayButton: false, showClear: false, useCurrent: 'hour', disabledDates: disabled_dates.presence }.compact
+        { format: format, showTodayButton: false, showClear: false, useCurrent: 'hour', disabledDates: disabled_dates.presence, locale: I18n.locale }.compact
       end
 
       def input_group_options


### PR DESCRIPTION
Hi,

This adds locale support for Date, Datetime and Time pickers.

For it to work it needs locale data from the MomentJS. EffectiveBoostrap doesn't ship moment with the locale. What I do is to include `gem 'momentjs-rails', '~> 2.9', github: 'derekprior/momentjs-rails'` in my Gemfile and then:

```
//= require moment/es.js
//= require moment/nl.js
```

But I think it would be better to either include the locale data in EffectiveBootstrap or simply add momentjs-rails as a dependency of effective_bootstrap. 

Thoughts?