### PR TITLE
inline_svg is deprecated

### DIFF
--- a/app/helpers/effective_icons_helper.rb
+++ b/app/helpers/effective_icons_helper.rb
@@ -8,7 +8,7 @@ module EffectiveIconsHelper
     options.reverse_merge!(nocomment: true)
     options[:class] = [options[:class], "eb-icon eb-icon-#{svg}"].compact.join(' ')
 
-    inline_svg("icons/#{svg}.svg", options)
+    inline_svg_tag("icons/#{svg}.svg", options)
   end
 
   def icon_to(svg, url, options = {})


### PR DESCRIPTION
Hi,

I was getting a bunch of deprecations when running my tests

````
DEPRECATION WARNING: `inline_svg` is deprecated and will be removed from inline_svg 2.0 (use `inline_svg_tag` or `inline_svg_pack_tag` instead)
````

And it appears to be that `inline_svg` is now deprecated. So we should use `inline_svg_tag`

See changelog in: https://github.com/jamesmartin/inline_svg/blob/master/CHANGELOG.md\#160---2019-11-13
