### PR TITLE
Don't apply default font styles to trix content

### DIFF
--- a/app/assets/stylesheets/effective_rich_text_area/extensions.scss
+++ b/app/assets/stylesheets/effective_rich_text_area/extensions.scss
@@ -61,19 +61,7 @@ trix-editor {
 }
 
 .trix-content {
-  h1, h2, h3, h4, h5, h6 {
-    line-height: 1.2;
-    margin: 0;
-  }
-
-  h1 { font-size: 36px; }
-  h2 { font-size: 26px; }
-  h3 { font-size: 18px; }
-  h4 { font-size: 18px; }
-  h5 { font-size: 14px; }
-  h6 { font-size: 12px; }
-
-  .attachment { width: 100%; }
+  .attachment { max-width: 100%; }
 
   .attachment--content.attachment--horizontal-rule,
   .attachment--content[data-trix-content-type~='vnd.rubyonrails.horizontal-rule.html'] {

--- a/app/assets/stylesheets/effective_rich_text_area/rich_text_area.scss
+++ b/app/assets/stylesheets/effective_rich_text_area/rich_text_area.scss
@@ -12,11 +12,6 @@
   }
 }
 
-// Trix image caption
-.trix-content {
-  figcaption.attachment__caption { display: none; }
-}
-
 // Bootstrap 4 Feedback client side
 .was-validated .form-control:invalid ~ .trix-content, { border-color: #dc3545 !important; }
 .was-validated .form-control:valid ~ .trix-content { border-color: #28a745 !important; }


### PR DESCRIPTION
These rules override bootstrap defaults e.g. `h2, .h2` loses in precedence to `.trix-content h2`, and should be removed. Content inside a .trix-content div should look the same as content outside of one, imo