### PR TITLE
Bootstrap valid/invalid feedback adjustment

### DIFF
--- a/app/assets/stylesheets/effective_bootstrap/forms.scss
+++ b/app/assets/stylesheets/effective_bootstrap/forms.scss
@@ -63,3 +63,5 @@ div.form-group > label + .btn-group { display: block; }
 
 .effective-checks.is-invalid .invalid-feedback { display: block; }
 .effective-checks.is-valid .valid-feedback { display: block; }
+
+.invalid-feedback, .valid-feedback { text-transform: capitalize; }

--- a/app/models/effective/form_input.rb
+++ b/app/models/effective/form_input.rb
@@ -129,6 +129,7 @@ module Effective
       content_tag(:div, '', options[:input_group][:input_group]) do # Twice here, kind of weird.
         [
           (content_tag(:div, options[:input_group][:prepend], class: 'input-group-prepend') if options[:input_group][:prepend]),
+          (content_tag(:div, options[:input_group][:append], class: 'input-group-append') if options[:input_group][:append]),
           build_input(&block)
         ].compact.join.html_safe
       end

--- a/app/models/effective/form_input.rb
+++ b/app/models/effective/form_input.rb
@@ -121,7 +121,7 @@ module Effective
       if layout == :horizontal
         build_input_group { build_input(&block) } + build_hint
       else
-        build_label + build_input_group { build_input(&block) } + build_hint
+        build_label + build_input_group { build_input(&block) } + build_feedback + build_hint
       end
     end
 
@@ -129,9 +129,7 @@ module Effective
       content_tag(:div, '', options[:input_group][:input_group]) do # Twice here, kind of weird.
         [
           (content_tag(:div, options[:input_group][:prepend], class: 'input-group-prepend') if options[:input_group][:prepend]),
-          build_input(&block),
-          (content_tag(:div, options[:input_group][:append], class: 'input-group-append') if options[:input_group][:append]),
-          build_feedback
+          build_input(&block)
         ].compact.join.html_safe
       end
     end
@@ -180,13 +178,10 @@ module Effective
 
       invalid = object.errors[name].to_sentence.presence if object.respond_to?(:errors)
       invalid ||= options[:feedback][:invalid].delete(:text).presence
-      invalid ||= [("can't be blank" if options[:input][:required]), ('must be valid' if validated?(name))].tap(&:compact!).join(' and ').presence
-      invalid ||= "can't be blank or is invalid"
+      invalid ||= [("Can't be blank" if options[:input][:required]), ('must be valid' if validated?(name))].tap(&:compact!).join(' and ').presence
+      invalid ||= "Can't be blank or is invalid"
 
-      valid = options[:feedback][:valid].delete(:text) || 'Looks good!'
-
-      content_tag(:div, invalid.html_safe, options[:feedback][:invalid]) +
-      content_tag(:div, valid.html_safe, options[:feedback][:valid])
+      content_tag(:div, invalid.html_safe, options[:feedback][:invalid])
     end
 
     def has_error?(name = nil)


### PR DESCRIPTION
- Move feedback outside of input group to fix rounding bug
- Don't show "Looks good!" for valid feedback, the green outline and checkbox is enough

![2022-01-12-062027](https://user-images.githubusercontent.com/23863/149148130-7e79e600-0bba-4f15-98d8-be611acd3352.png)
