### PR TITLE
Fix show_if/hide_if/show_if_any nested enable and checkbox handling

### DIFF
--- a/app/assets/javascripts/effective_bootstrap/logic.js.coffee
+++ b/app/assets/javascripts/effective_bootstrap/logic.js.coffee
@@ -13,15 +13,19 @@ elementSelector = 'input,textarea,select,button,div.form-has-many'
     matches = ($target.val() == options.value)
 
     if $target.is("[type='checkbox']")
-      matches = matches || ($target.is(':checked') && "#{options.value}" == 'true')
-      matches = matches || (!$target.is(':checked') && ("#{options.value}" == 'false' || "#{options.value}" == ''))
+      if $target.attr('name').indexOf('[]') == -1
+        matches = matches || ($target.is(':checked') && "#{options.value}" == 'true')
+        matches = matches || (!$target.is(':checked') && ("#{options.value}" == 'false' || "#{options.value}" == ''))
+      else
+        selected = $target.closest('fieldset').find("[name='#{options.name}[]']:checked").map((i, el) -> $(el).val()).get()
+        matches = selected.find((value) => (value == options.value || "#{value}" == "#{options.value}"))
 
     if matches
       $element.hide()
       $element.find(elementSelector).prop('disabled', true)
     else
       $element.fadeIn()
-      $element.find(elementSelector).removeAttr('disabled')
+      $element.find(elementSelector).not($element.find('.effective-form-logic:hidden').find(elementSelector)).removeAttr('disabled')
       $element.find('textarea.effective_article_editor').each (i, editor) -> ArticleEditor('#' + $(editor).attr('id')).enable()
 
   # Maybe disable it now
@@ -50,7 +54,7 @@ elementSelector = 'input,textarea,select,button,div.form-has-many'
 
     if matches
       $element.fadeIn()
-      $element.find(elementSelector).removeAttr('disabled')
+      $element.find(elementSelector).not($element.find('.effective-form-logic:hidden').find(elementSelector)).removeAttr('disabled')
       $element.find('textarea.effective_article_editor').each (i, editor) -> ArticleEditor('#' + $(editor).attr('id')).enable()
     else
       $element.hide()
@@ -71,12 +75,21 @@ elementSelector = 'input,textarea,select,button,div.form-has-many'
   values = JSON.parse(options.value)
 
   $affects.on 'change dp.change', (event) ->
-    selected = $(event.target).val()
+    $target = $(event.target)
+    selected = $target.val()
     found = values.find((value) => (value == selected || "#{value}" == "#{selected}"))
+
+    if $target.is("[type='checkbox']")
+      if $target.attr('name').indexOf('[]') == -1
+        found = found || ($target.is(':checked') && values.find((value) => "#{value}" == 'true'))
+        found = found || (!$target.is(':checked') && values.find((value) => ("#{value}" == 'false' || "#{value}" == '')))
+      else
+        checked = $target.closest('fieldset').find("[name='#{options.name}[]']:checked").map((i, el) -> $(el).val()).get()
+        found = values.find((value) => checked.find((sel) => (sel == value || "#{sel}" == "#{value}")))
 
     if found
       $element.fadeIn()
-      $element.find(elementSelector).removeAttr('disabled')
+      $element.find(elementSelector).not($element.find('.effective-form-logic:hidden').find(elementSelector)).removeAttr('disabled')
       $element.find('textarea.effective_article_editor').each (i, editor) -> ArticleEditor('#' + $(editor).attr('id')).enable()
 
     else


### PR DESCRIPTION
## Summary
- Fix nested show_if cascade: when a parent block enables inputs on show, it now skips inputs inside hidden child `.effective-form-logic` blocks — previously it blindly enabled ALL nested inputs, causing hidden fields to submit
- Add checkbox array handling to `hide_if` to match `show_if` (distinguishes single checkbox from checkbox collection `name[]`)
- Add checkbox handling to `show_if_any` (was missing entirely — `.val()` on a checkbox returns its value attribute, not checked state)

## Test plan
- [ ] Test nested show_if blocks (e.g. `show_if(:scored, true)` wrapping `show_if(:category, 'Number')` wrapping `show_if(:operation, 'Within range')`) — toggling outer should not enable inputs in hidden inner blocks
- [ ] Test `hide_if` with a checks collection input — should correctly hide/show based on checked values
- [ ] Test `show_if_any` with checkbox inputs — should match on checked/unchecked state, not just value attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)