### PR TITLE
Add imagehover plugin support

### DIFF
--- a/app/assets/javascripts/effective_article_editor/initialize.js.coffee
+++ b/app/assets/javascripts/effective_article_editor/initialize.js.coffee
@@ -51,6 +51,11 @@ uploadActiveStorage = (editor, data) ->
         .addClass(classes)
 
       doc
+        .find("img[data-hover-src^='#{rails_url}']:not(.effective-article-editor-hover-attachment)")
+        .after(attachment)
+        .addClass('effective-article-editor-hover-attachment')
+
+      doc
         .find("a[data-file][data-name='#{file.name}']:not(.action-text-attachment)")
         .after(attachment)
         .addClass(classes)

--- a/app/models/effective/form_inputs/article_editor.rb
+++ b/app/models/effective/form_inputs/article_editor.rb
@@ -101,7 +101,7 @@ module Effective
             }
           },
           outset: false, # tricky to design around
-          plugins: ['blockcode', 'carousel', 'cellcolor', 'collapse', 'filelink', 'imageposition', 'imageresize', 'inlineformat', 'listitem', 'makebutton', 'removeformat', 'reorder', 'style'],
+          plugins: ['blockcode', 'carousel', 'cellcolor', 'collapse', 'filelink', 'imagehover', 'imageposition', 'imageresize', 'inlineformat', 'listitem', 'makebutton', 'removeformat', 'reorder', 'style'],
 
           quote: {
             template: '<blockquote class="blockquote text-center"><p class="mb-0"><strong>A well-known quote, contained in a blockquote element.</strong></p></blockquote>'


### PR DESCRIPTION
## Summary
- Add `imagehover` to the default Article Editor plugins list
- Track hover image blobs with `<action-text-attachment>` elements in the ActiveStorage upload handler so blobs are not garbage-collected

Companion PR: code-and-effect/effective_article_editor (imagehover branch)

## Test plan
- [ ] Verify imagehover plugin is active by default when using `f.article_editor`
- [ ] Upload a hover image and confirm an `<action-text-attachment>` is created for the blob
- [ ] Confirm the hover image ActiveStorage URL persists across save/reload cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)