### PR TITLE
Add drag-and-drop support for file inputs

### DIFF
--- a/app/assets/javascripts/effective_file/initialize.js.coffee
+++ b/app/assets/javascripts/effective_file/initialize.js.coffee
@@ -1,7 +1,7 @@
 $(document).on 'direct-upload:initialize', (event) ->
   $target = $(event.target)
   template = $target.data('progress-template').replace('$ID$', event.detail.id).replace('$FILENAME$', event.detail.file.name)
-  $target.siblings('.uploads').append(template)
+  $target.closest('.effective-file-drop-zone').siblings('.uploads').append(template)
 
 $(document).on 'direct-upload:start', (event) ->
   $("[data-direct-upload-id=#{event.detail.id}]").removeClass('direct-upload--pending')
@@ -28,3 +28,42 @@ $(document).on 'direct-upload:end', (event) ->
 
 $(document).on 'change', "input[type='file'][data-click-submit]", (event) ->
   $(event.currentTarget).closest('form').find('button[type=submit],input[type=submit]').first().click()
+
+# Drag-and-drop support for file inputs
+$(document).on 'dragover', '.effective-file-drop-zone', (event) ->
+  event.preventDefault()
+  event.originalEvent.dataTransfer.dropEffect = 'copy'
+
+$(document).on 'dragenter', '.effective-file-drop-zone', (event) ->
+  event.preventDefault()
+  $zone = $(event.currentTarget)
+  count = ($zone.data('drag-count') || 0) + 1
+  $zone.data('drag-count', count)
+  $zone.addClass('drag-over')
+
+$(document).on 'dragleave', '.effective-file-drop-zone', (event) ->
+  event.preventDefault()
+  $zone = $(event.currentTarget)
+  count = ($zone.data('drag-count') || 0) - 1
+  $zone.data('drag-count', count)
+  $zone.removeClass('drag-over') if count <= 0
+
+$(document).on 'drop', '.effective-file-drop-zone', (event) ->
+  event.preventDefault()
+  $zone = $(event.currentTarget)
+  $zone.removeClass('drag-over').data('drag-count', 0)
+
+  $input = $zone.find('input[type=file]')
+  return if $input.prop('disabled') || $input.prop('readonly')
+
+  files = event.originalEvent.dataTransfer.files
+  return unless files.length > 0
+
+  if $input.prop('multiple')
+    $input[0].files = files
+  else
+    dt = new DataTransfer()
+    dt.items.add(files[0])
+    $input[0].files = dt.files
+
+  $input.trigger('change')

--- a/app/assets/stylesheets/effective_file/input.scss
+++ b/app/assets/stylesheets/effective_file/input.scss
@@ -43,6 +43,16 @@ table.effective_file_attachments {
   img { max-width: 128px; max-height: 128px;}
 }
 
+.effective-file-drop-zone {
+  position: relative;
+
+  &.drag-over input.form-control-file {
+    border-color: $primary;
+    border-style: dashed;
+    background-color: rgba($primary, 0.05);
+  }
+}
+
 input.form-control-file {
   border: solid 1px;
   padding: 1rem 0 1rem 1rem !important;

--- a/app/models/effective/form_inputs/file_field.rb
+++ b/app/models/effective/form_inputs/file_field.rb
@@ -142,13 +142,15 @@ module Effective
       end
 
       def build_uploads_and_purge(super_file_field)
+        wrapped_input = content_tag(:div, super_file_field, class: 'effective-file-drop-zone')
+
         if purge? && attachments_present?
           content_tag(:div) do
-            content_tag(:div, (build_uploads + super_file_field), class: 'mb-3') +
+            content_tag(:div, (build_uploads + wrapped_input), class: 'mb-3') +
             content_tag(:div, build_purge)
           end
         else
-          build_uploads + super_file_field
+          build_uploads + wrapped_input
         end
       end
 


### PR DESCRIPTION
## Summary

- Wraps file inputs in a `.effective-file-drop-zone` container div so drag/drop events can be scoped to the input area
- Adds `dragover`, `dragenter`, `dragleave`, and `drop` event handlers that let users drop files directly onto file inputs
- Dropped files are assigned to the input and trigger a `change` event so Active Storage Direct Upload picks them up automatically
- Adds `.drag-over` CSS styling (dashed primary border + light background) to give visual feedback during drag
- Fixes the `.siblings('.uploads')` selector to traverse up through the new wrapper div via `.closest('.effective-file-drop-zone')`

## Browser Compatibility

**Desktop** — All modern browsers supported:
- `dragover`/`dragenter`/`dragleave`/`drop` events, `event.originalEvent.dataTransfer`, and `new DataTransfer()` are universally supported (Chrome 62+, Firefox 62+, Safari 14.1+)
- Uses a **drag-count pattern** on `dragenter`/`dragleave` to handle the well-known browser issue where child elements re-fire these events, causing the drop zone highlight to flicker. The counter ensures the `drag-over` class is only removed when the pointer truly leaves the zone.

**Mobile/Touch** — Graceful degradation:
- HTML5 drag-and-drop events do not fire on mobile browsers, so the drag/drop handlers are effectively inert on touch devices
- File inputs still work normally via tap → native file picker (no regression)
- The `.drag-over` CSS class is never applied on mobile, so no visual glitches

## Files Changed

| File | Change |
|------|--------|
| `app/models/effective/form_inputs/file_field.rb` | Wraps file input in `.effective-file-drop-zone` div |
| `app/assets/javascripts/effective_file/initialize.js.coffee` | Fixes `.siblings('.uploads')` selector + adds drag/drop handlers |
| `app/assets/stylesheets/effective_file/input.scss` | Adds drop zone and drag-over styling |

## Test plan
- [ ] Drag a file onto a single-file input — file should upload via Direct Upload
- [ ] Drag a file onto a multi-file input — file should upload
- [ ] Drag multiple files onto a single-file input — only the first file should be used
- [ ] Verify drag-over visual feedback (dashed border) appears/disappears correctly
- [ ] Verify the upload progress bar still appears in `.uploads` container
- [ ] Test on mobile — tap file input should still open native file picker as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)