### PR TITLE
Preserve history.state when updating tab hash

### DIFF
--- a/app/assets/javascripts/effective_bootstrap/tabs.js
+++ b/app/assets/javascripts/effective_bootstrap/tabs.js
@@ -1,6 +1,6 @@
 // Set the document hash to the tab href
 $(document).on('show.bs.tab', function (e) {
-  history.replaceState(null, null, '#' + e.target.getAttribute('id'));
+  history.replaceState(history.state, null, '#' + e.target.getAttribute('id'));
 });
 
 // Display the tab based on form errors, the document hash, or ?tab= params


### PR DESCRIPTION
## Summary

The `show.bs.tab` handler in `tabs.js` was calling `history.replaceState(null, null, '#tab-xxx')`, which wiped the current history entry's state object. Turbolinks stores `{turbolinks: {restorationIdentifier: ...}}` in `history.state` and checks for it on `popstate` to decide whether to restore a page snapshot.

When the state was `null`, Turbolinks no-oped the popstate — the URL would update in the address bar but the page content would not change.

## Repro (before fix)

1. Visit any admin page with a tab hash (e.g. `/admin/users/567/edit#tab-wetlands-ap`)
2. Navigate to another page via the navbar (e.g. `/admin/memberships`)
3. Click into a record (e.g. `/admin/users/13/edit#tab-membership`)
4. Click back → memberships index loads correctly
5. Click back again → URL updates to the original user edit page, but the page content stays on memberships ❌

The second back fails because on the initial page load, the tab activation fires `show.bs.tab` → `replaceState(null, ...)` wipes Turbolinks' state at that history entry. When the user eventually pops back to that entry, `event.state.turbolinks` is `undefined` and Turbolinks bails out of the restore.

## Fix

Pass `history.state` as the first argument so the existing state object is preserved when we rewrite only the URL hash:

```diff
- history.replaceState(null, null, '#' + e.target.getAttribute('id'));
+ history.replaceState(history.state, null, '#' + e.target.getAttribute('id'));
```

## Test plan

- [ ] Walk through the repro above; second back navigates correctly
- [ ] Clicking between tabs on a page still updates the URL hash
- [ ] Reloading a page with a tab hash still activates the correct tab (unchanged — URL rewrite still happens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)